### PR TITLE
Add nflvid-watch --fetch-missing

### DIFF
--- a/nflvid/vlc.py
+++ b/nflvid/vlc.py
@@ -172,6 +172,10 @@ def plays_and_paths(plays, footage_play_dir=None):
         path = _play_path(footage_play_dir, play)
         if path is not None:
             al.append((play, path))
+        else:
+            print('Missing play %d from game %s' % (
+                play.play_id, play.gsis_id))
+
     return al
 
 

--- a/scripts/nflvid-watch
+++ b/scripts/nflvid-watch
@@ -11,6 +11,7 @@ Clock = Clock.from_str
 Field = FieldPosition.from_str
 PTime = PossessionTime.from_str
 
+import nflgame
 import nflvid
 import nflvid.vlc
 
@@ -85,6 +86,8 @@ if __name__ == '__main__':
     aa('--hide-marquee', action='store_true',
        help='When set, there will be no text overlay on the footage '
             'describing the game context or the play.')
+    aa('--fetch-missing', action='store_true',
+       help='When set, nflvid-watch will attempt to fetch any missing plays.')
     args = parser.parse_args()
 
     if not args.text:
@@ -129,6 +132,20 @@ if __name__ == '__main__':
         for p in plays:
             print(p.gsis_id, '%04d' % p.play_id, p.time, p.description)
         sys.exit(0)
+
+    if args.fetch_missing:
+        for db_play in plays:
+            db_game = db_play.drive.game
+            mapping = {
+                'Postseason': 'POST',
+                'Preseason': 'PRE',
+                'Regular': 'REG',
+            }
+            game = nflgame.one(
+                db_game.season_year, week=db_game.week, home=db_game.home_team,
+                away=db_game.away_team, kind=mapping[db_game.season_type.name])
+            nflvid.fetch_single_slice(
+                args.footage_play_dir, game, db_play.play_id)
 
     try:
         nflvid.vlc.watch(db, plays, footage_play_dir=args.footage_play_dir,


### PR DESCRIPTION
This will use rtmpdump's --start and --stop parameters to fetch the play in question and put it in the appropriate play-by-play location before vlc starts up.